### PR TITLE
Fix some spelling

### DIFF
--- a/.emacs.d/emacs.org
+++ b/.emacs.d/emacs.org
@@ -74,7 +74,7 @@ It looks kinda like that (click to open the real one) :
      (add-to-list 'package-archives '("mela-stable" . "http://stable.melpa.org/packages/"))
 
      ;; If gpg cannot be found, signature checking will fail, so we
-     ;; conditionnally enable it according wether gpg is availabel.
+     ;; conditionally enable it according whether gpg is available.
      ;; We re-run this check once $PATH has been configured
      (defun sanityinc/package-maybe-enable-signatures ()
        (setq package-check-signature (when (executable-find "gpg") 'allow-unsigned)))


### PR DESCRIPTION
This repo was referenced on a [hacker news post](https://news.ycombinator.com/item?id=9593322), and I can't help but edit.
